### PR TITLE
修复swoole服务在WIN环境重命名进程名的方法报错，导致服务启动死循环的BUG

### DIFF
--- a/src/server/BaseServer.php
+++ b/src/server/BaseServer.php
@@ -202,14 +202,17 @@ class BaseServer
      */
     private static function setProcessName($process)
     {
-        // Mac OSX不支持进程重命名
-        if (stristr(PHP_OS, 'DAR')) {
+        // Mac OSX WIN不支持进程重命名
+        if (stristr(PHP_OS, 'DAR') || stristr(PHP_OS, 'CYGWIN')) {
             return;
         }
-        $serverName = 'swoole_http_server';
-        $appName    = config('app.name', 'topphp');
-        $name       = sprintf('%s: %s for %s', $serverName, $process, $appName);
-        swoole_set_process_name($name);
+        try {
+            $serverName = 'swoole_http_server';
+            $appName    = config('app.name', 'topphp');
+            $name       = sprintf('%s: %s for %s', $serverName, $process, $appName);
+            @swoole_set_process_name($name);
+        } catch (Throwable $e) {
+        }
     }
 
     /**


### PR DESCRIPTION
修复swoole服务在WIN环境重命名进程名的方法报错，导致服务启动死循环的BUG